### PR TITLE
fix: wrong completion parameters for xonsh

### DIFF
--- a/bin/capture.xonsh
+++ b/bin/capture.xonsh
@@ -1,5 +1,6 @@
 #!/usr/bin/env xonsh
 
 import xonsh.completer
-for i in xonsh.completer.Completer().complete("", "", 0, 0, {}, multiline_text="git ch", cursor_index=6)[0]:
+
+for i in xonsh.completer.Completer().complete("", "", 0, 0, {}, multiline_text=$ARG1, cursor_index=len($ARG1))[0]:
   print(i)


### PR DESCRIPTION
My bad... Internal parameters for `capture.xonsh` is completely wrong.
This PR fixes it.