### PR TITLE
feat: support completion after space

### DIFF
--- a/denops/@ddc-sources/shell-native.ts
+++ b/denops/@ddc-sources/shell-native.ts
@@ -15,7 +15,7 @@ export class Source extends BaseSource<Params> {
   override getCompletePosition(args: {
     context: Context;
   }): Promise<number> {
-    const matchPos = args.context.input.search(/\S+$/);
+    const matchPos = args.context.input.search(/\S*$/);
     const completePos = matchPos !== null ? matchPos : -1;
     return Promise.resolve(completePos);
   }


### PR DESCRIPTION

![image](https://github.com/Shougo/ddc-source-shell-native/assets/30277794/21c204d2-514d-4050-a1dd-a8137873c29c)


reproducible example

do `:git<space>` with the following config (sorry but in lua)

``` lua
vim.opt.runtimepath:prepend("~/.local/share/nvim/lazy/pum.vim")
vim.opt.runtimepath:prepend("~/.local/share/nvim/lazy/denops.vim")
vim.opt.runtimepath:prepend("~/.local/share/nvim/lazy/ddc.vim")
vim.opt.runtimepath:prepend("~/.local/share/nvim/lazy/ddc-ui-pum")
vim.opt.runtimepath:prepend("/home/atusy/ghq/github.com/Shougo/ddc-source-shell-native")
vim.opt.runtimepath:prepend("~/.local/share/nvim/lazy/ddc-matcher_head")

vim.fn["ddc#custom#patch_global"]({
  ui = "pum",
  autoCompleteEvents = { "CmdlineChanged" },
  -- cmdlineSources = { [":"] = { "sh", "cmdline" } },
  cmdlineSources = { [":"] = { "shell-native" } },
  sourceOptions = {
    ["_"] = { matchers = { "matcher_head" } },
    ["shell-native"] = {
      mark = "shell",
      isVolatile = true,
      minAutoCompleteLength = 0,
      minKeywordLength = 0,
    },
  },
  sourceParams = { ["shell-native"] = { shell = "fish" } },
})

function CommandlinePre()
  vim.fn["ddc#enable_cmdline_completion"]()
end

vim.keymap.set("n", ":", "<Cmd>lua CommandlinePre()<CR>:")
```
